### PR TITLE
Evolve[Doc]: Continuous and Noncontinuous

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Powerful SQL migration toolkit for Rust.
 <br/>
 
 Refinery strives to make running migrations for different databases as easy as possible.
-It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via the `refinery` CLI.
+It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via the [refinery_cli].
 
 Currently [`postgres`](https://crates.io/crates/postgres), [`tokio-postgres`](https://crates.io/crates/tokio-postgres) , [`mysql`](https://crates.io/crates/mysql), [`mysql_async`](https://crates.io/crates/mysql_async), [`rusqlite`](https://crates.io/crates/rusqlite) and [`tiberius`](https://github.com/prisma/tiberius) are supported.
 If you are using a driver that is not yet supported, namely [`SQLx`](https://github.com/launchbadge/sqlx) you can run migrations providing a [`Config`](https://docs.rs/refinery/latest/refinery/config/struct.Config.html) instead of the connection type, as `Config` impl's `Migrate`. You will still need to provide the `postgres`/`mysql`/`rusqlite`/`tiberius` driver as a feature for [`Runner::run`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run) and `tokio-postgres`/`mysql_async` for [`Runner::run_async`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run_async).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Powerful SQL migration toolkit for Rust.
 <br/>
 
 `refinery` makes running migrations for different databases as easy as possible.
-It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via `refinery_cli`.
+It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via [refinery_cli].
 Currently [`postgres`](https://crates.io/crates/postgres), [`tokio-postgres`](https://crates.io/crates/tokio-postgres) , [`mysql`](https://crates.io/crates/mysql), [`mysql_async`](https://crates.io/crates/mysql_async), [`rusqlite`](https://crates.io/crates/rusqlite) and [`tiberius`](https://github.com/prisma/tiberius) are supported.\
 If you are using a driver that is not yet supported, namely [`SQLx`](https://github.com/launchbadge/sqlx) you can run migrations providing a [`Config`](https://docs.rs/refinery/latest/refinery/config/struct.Config.html) instead of the connection type, as `Config` impl's `Migrate`. You will still need to provide the `postgres`/`mysql`/`rusqlite`/`tiberius` driver as a feature for [`Runner::run`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run) and `tokio-postgres`/`mysql_async` for [`Runner::run_async`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run_async).\
 `refinery` works best with [`Barrel`](https://crates.io/crates/barrel) but you can also have your migrations in .sql files or use any other Rust crate for schema generation.
@@ -32,7 +32,7 @@ If you are using a driver that is not yet supported, namely [`SQLx`](https://git
 - Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](https://doc.rust-lang.org/std/string/struct.String.html).
 - Migrations can be strictly versioned by prefixing the file with `V` or not strictly versioned by prefixing the file with `U`.
 - Migrations, both .sql files and Rust modules must be named in the format `[U|V]{1}__{2}.sql` or `[U|V]{1}__{2}.rs`, where `{1}` represents the migration version and `{2}` the name.
-- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via `refinery_cli`.
+- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via [refinery_cli].
 
 ### Example
 ```rust,no_run
@@ -95,3 +95,5 @@ This project is licensed under the [MIT license](LICENSE).
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in refinery by you, shall be licensed as MIT, without any additional
 terms or conditions.
+
+[refinery_cli]: https://crates.io/crates/refinery_cli

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you are using a driver that is not yet supported, namely [`SQLx`](https://git
 - Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](https://doc.rust-lang.org/std/string/struct.String.html).
 - Migrations can be strictly versioned by prefixing the file with `V` or not strictly versioned by prefixing the file with `U`.
 - Migrations, both .sql files and Rust modules must be named in the format `[U|V]{1}__{2}.sql` or `[U|V]{1}__{2}.rs`, where `{1}` represents the migration version and `{2}` the name.
-- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via [`refinery`](refinery_cli) CLI`.
+- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via [refinery_cli].
 
 ### Example: Library
 ```rust,no_run

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ For more library examples, refer to the [`examples`](examples).
 
 NOTE: 
 
-- Continuous migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
-- Noncontinuous migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
+- Contiguous (adjacent) migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
+- Non-contiguous (not adjacent) migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
 
 ```bash
 export DATABASE_URL="postgres://postgres:secret@localhost:5432/your-db"
@@ -66,16 +66,16 @@ pushd migrations
 popd
 ```
 
-### Noncontinuous VS Continuous migrations
+### Non-contiguous VS Contiguous migrations
 
-Depending on how your project / team has been structured will define whether you want to use Continuous migrations `V{1}__{2}.[sql|rs]` or non-sequential migrations `U{1}__{2}.[sql|rs]`.
-If all migrations are created sequentially and, are deployed in the order they were developed, you won't run into any problems using Continuous migrations.
+Depending on how your project/team has been structured will define whether you want to use contiguous (adjacent) migrations `V{1}__{2}.[sql|rs]` or non-contiguous (not adjacent) migrations `U{1}__{2}.[sql|rs]`.
+If migration sequential numbering reflects the order they were developed and, they are deployed in the order they are numbered, you won't run into any problems using contiguous migrations.
 This is because you can be sure the next migration being run is _always_ going to have a version number greater than the previous.
 
-With Noncontinuous migrations there is more flexibility in the order that the migrations can be created and deployed.
+With non-contiguous migrations there is more flexibility in the order that the migrations can be created and deployed.
 If developer 1 creates a PR with a migration today `U11__update_cars_table.sql`, but it is reviewed for a week.
 Meanwhile, developer 2 creates a PR with migration `U12__create_model_tags.sql` that is much simpler and gets merged and deployed immediately.
-This would stop developer 1's migration from ever running if you were using Continuous migrations because the next migration would need to be > 12.
+This would stop developer 1's migration from ever running if you were using contiguous migrations because the next migration would need to be > 12.
 
 ## Implementation details
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you are using a driver that is not yet supported, namely [`SQLx`](https://git
 - Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](https://doc.rust-lang.org/std/string/struct.String.html).
 - Migrations can be strictly versioned by prefixing the file with `V` or not strictly versioned by prefixing the file with `U`.
 - Migrations, both .sql files and Rust modules must be named in the format `[U|V]{1}__{2}.sql` or `[U|V]{1}__{2}.rs`, where `{1}` represents the migration version and `{2}` the name.
-- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via `refinery` CLI`.
+- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via [`refinery`](refinery_cli) CLI`.
 
 ### Example: Library
 ```rust,no_run

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Powerful SQL migration toolkit for Rust.
 </div>
 <br/>
 
-Refinery makes running migrations for different databases as easy as possible.
-It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via `refinery` CLI.
+Refinery strives to make running migrations for different databases as easy as possible.
+It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via the `refinery` CLI.
 Currently [`postgres`](https://crates.io/crates/postgres), [`tokio-postgres`](https://crates.io/crates/tokio-postgres) , [`mysql`](https://crates.io/crates/mysql), [`mysql_async`](https://crates.io/crates/mysql_async), [`rusqlite`](https://crates.io/crates/rusqlite) and [`tiberius`](https://github.com/prisma/tiberius) are supported.\
 If you are using a driver that is not yet supported, namely [`SQLx`](https://github.com/launchbadge/sqlx) you can run migrations providing a [`Config`](https://docs.rs/refinery/latest/refinery/config/struct.Config.html) instead of the connection type, as `Config` impl's `Migrate`. You will still need to provide the `postgres`/`mysql`/`rusqlite`/`tiberius` driver as a feature for [`Runner::run`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run) and `tokio-postgres`/`mysql_async` for [`Runner::run_async`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run_async).\
 `refinery` works best with [`Barrel`](https://crates.io/crates/barrel) but you can also have your migrations in `.sql` files or use any other Rust crate for schema generation.
@@ -55,8 +55,8 @@ For more library examples, refer to the [`examples`](examples).
 
 NOTE: 
 
-- Sequential migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
-- Non-sequential migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
+- Continuous migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
+- Noncontinuous migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
 
 ```bash
 export DATABASE_URL="postgres://postgres:secret@localhost:5432/your-db"
@@ -66,16 +66,16 @@ pushd migrations
 popd
 ```
 
-### Non-sequential VS Sequential migrations
+### Noncontinuous VS Continuous migrations
 
-Depending on how your project / team has been structured will define whether you want to use sequential migrations `V{1}__{2}.[sql|rs]` or non-sequential migrations `U{1}__{2}.[sql|rs]`.
-If all migrations are created synchronously and are deployed synchronously you won't run into any problems using Sequential migrations.
+Depending on how your project / team has been structured will define whether you want to use Continuous migrations `V{1}__{2}.[sql|rs]` or non-sequential migrations `U{1}__{2}.[sql|rs]`.
+If all migrations are created sequentially and, are deployed in the order they were developed, you won't run into any problems using Continuous migrations.
 This is because you can be sure the next migration being run is _always_ going to have a version number greater than the previous.
 
-With Non-sequential migrations there is more flexibility in the order that the migrations can be created and deployed.
+With Noncontinuous migrations there is more flexibility in the order that the migrations can be created and deployed.
 If developer 1 creates a PR with a migration today `U11__update_cars_table.sql`, but it is reviewed for a week.
 Meanwhile, developer 2 creates a PR with migration `U12__create_model_tags.sql` that is much simpler and gets merged and deployed immediately.
-This would stop developer 1's migration from ever running if you were using Sequential migrations because the next migration would need to be > 12.
+This would stop developer 1's migration from ever running if you were using Continuous migrations because the next migration would need to be > 12.
 
 ## Implementation details
 

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -34,7 +34,7 @@ rusqlite = { version = ">= 0.23, <= 0.27", optional = true }
 postgres = { version = "0.19", optional = true }
 tokio-postgres-driver = { package = "tokio-postgres", version = "0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 22", optional = true, default-features = false}
-mysql-async-driver = { package = "mysql_async", version = ">= 0.28, <= 0.29", optional = true }
+mysql-async-driver = { package = "mysql_async", version = ">= 0.28, <= 0.30", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 tiberius-driver = { package = "tiberius", version = "0.7", optional = true }
 futures = { version = "0.3.16", optional = true }

--- a/refinery_core/src/drivers/mysql_async.rs
+++ b/refinery_core/src/drivers/mysql_async.rs
@@ -47,7 +47,7 @@ impl AsyncTransaction for Pool {
         let mut transaction = conn.start_transaction(options).await?;
         let mut count = 0;
         for query in queries {
-            transaction.query_drop(query).await?;
+            transaction.query_drop(*query).await?;
             count += 1;
         }
         transaction.commit().await?;


### PR DESCRIPTION
The existing Versioned and Unversioned adjectives lead to this type of sentence:

> Unversioned migration version numbers are restricted to `u32` (unsigned, 32-bit integers).

This seems less contradictory:

> Noncontinuous migration version numbers are restricted to `u32` (unsigned, 32-bit integers).